### PR TITLE
dev: protection stored as mappingproxy for proper inheritance checks.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,14 +376,7 @@ paramclasses.paramclasses.ProtectedError: Incoherent protection inheritance for 
 
 It is possible to inherit from a mix of paramclasses and non-paramclasses, with the two following limitations.
 
-1. This metaclasses inheritance scheme must be respected:
-```python
-type(ParamClass) -> ABCMeta -> type
-```
-As such, bases must be ordered like below.
-```python
-(*paramclasses, *abstractclasses, *vanillaclasses)
-```
+1. Because `type(ParamClass)` is a subclass of `ABCMeta`, non-paramclass bases must be either vanilla classes or abstract class.
 
 2. Behaviour is not guaranteed for non-paramclass bases with attributes corresponding to either `DEFAULT` or `PROTECTED` values -- _see [Subclassing API](#3-subclassing-api-)_.
 

--- a/test/paramclasses/test_getsetdel_behaviour.py
+++ b/test/paramclasses/test_getsetdel_behaviour.py
@@ -48,7 +48,7 @@ def test_behaviour_set_del_protected_class_and_instances(
     param = obj("Param")
     param_full = obj("Param", fill_dict=True)
     for attr in paramtest_attrs("protected"):
-        regex = f"^Attribute '{attr}' is protected$"
+        regex = f"^'{attr}' is protected by 'ParamTest'"
         assert_set_del_is_protected(param, attr, regex)
         assert_set_del_is_protected(param_full, attr, regex)
         assert_set_del_is_protected(ParamTest, attr, regex)

--- a/test/paramclasses/test_paramclasses.py
+++ b/test/paramclasses/test_paramclasses.py
@@ -20,7 +20,7 @@ def test_slot_compatible(null):
     assert "x" not in vars(a)
 
 
-@pytest.mark.skip(reason="Don't want to monkeypatch, treat #4 before")
+# @pytest.mark.skip(reason="Don't want to monkeypatch, treat #4 before")
 def test_repr_with_missing_and_recursion(ParamTest):
     """Show non-default and missing in `repr`, handle recursive."""
 
@@ -33,7 +33,7 @@ def test_repr_with_missing_and_recursion(ParamTest):
 
     expected = (
         "ReprTest("
-        "a_unprotected_parameter_with_nodefaultvalue=?, "
+        "a_unprotected_parameter_with_missing=?, "
         "a_unprotected_parameter_slot=<member 'a_unprotected_parameter_slot' of"
         " 'ParamTest' objects>, "
         "a_recursive_parameter=...)"
@@ -48,23 +48,9 @@ def test_missing_params(ParamTest, paramtest_attrs):
     assert expected == paramtest_missing
 
 
-def test_repr_replace_above_while_issue_4() -> None:
-    """String representation, with missing value and recursion."""
-
-    class A(ParamClass):
-        a = 0
-        b: int = 1
-        c: int
-        d: type
-
-    x = A(b=2)
-    x.c = x
-    assert repr(x) == "A(b=2, c=..., d=?)"
-
-
 def test_cannot_define_double_dunder_parameter():
-    """Double dunder parameters are forbidden."""
-    regex = r"^Double dunder parameters \('__'\) are forbidden$"
+    """Dunder parameters are forbidden."""
+    regex = r"^Dunder parameters \('__'\) are forbidden$"
     with pytest.raises(AttributeError, match=regex):
 
         class A(ParamClass):


### PR DESCRIPTION
… closes #4

A bit more verbosity in errors.