### PR TITLE
33: `__post_init__` signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ def __init__(self, args: list[object] = [], kwargs: dict[str, object] = {}, /, *
 
 Since parameter values are set before `__post_init__` is called, they are accessible when it executes. Note that even if a _paramclass_ does not define `__post_init__`, its bases might, in which case it is used.
 
+Additionally, both `@staticmethod` and `@classmethod` decorators are supported decorators for `__post_init__` declaration. In other cases, the `__signature__` property may fail.
+
 <sup>Back to [Table of Contents](#readme)👆</sup>
 
 #### Abstract methods

--- a/README.md
+++ b/README.md
@@ -222,13 +222,13 @@ and is called as follows by `__init__`.
 ```python
 # Close equivalent to actual implementation
 @protected
-def __init__(self, args: list = [], kwargs: dict = {}, /, **param_values: object) -> None:
+def __init__(self, args: list[object] = [], kwargs: dict[str, object] = {}, /, **param_values: object) -> None:
         self.set_params(**param_values)
         self.__post_init__(*args, **kwargs)
 
 ```
 
-Since parameter values are set before `__post_init__` is called, they are accessible when it executes.
+Since parameter values are set before `__post_init__` is called, they are accessible when it executes. Note that even if a _paramclass_ does not define `__post_init__`, its bases might, in which case it is used.
 
 <sup>Back to [Table of Contents](#readme)👆</sup>
 
@@ -253,14 +253,11 @@ TypeError: Can't instantiate abstract class A with abstract method next
 
 ## 3. Subclassing API 👩‍💻
 
-As seen in [Additional functionalities](#additional-functionalities), three methods may be overriden by subclasses.
+As seen in [Additional functionalities](#additional-functionalities), three methods may be implemented by subclasses.
 ```python
 # ===================== Subclasses may override these ======================
 def _on_param_will_be_set(self, attr: str, future_val: object) -> None:
     """Call before parameter assignment."""
-
-def __post_init__(self, *args: object, **kwargs: object) -> None:
-    """Init logic, after parameters assignment."""
 
 def __repr__(self) -> str:
     """Show all params, e.g. `A(x=1, z=?)`."""
@@ -268,6 +265,9 @@ def __repr__(self) -> str:
 def __str__(self) -> str:
     """Show all nondefault or missing, e.g. `A(z=?)`."""
 
+# ===================== Subclasses may introduce these =====================
+def __post_init__(self, *args: object, **kwargs: object) -> None:
+    """Init logic, after parameters assignment."""
 
 ```
 
@@ -280,8 +280,8 @@ Furthermore, _as a last resort_, developers may occasionally wish to use the fol
 # Recommended way of using `IMPL`
 from paramclasses import IMPL, ParamClass
 
-getattr(ParamClass, IMPL).annotations    # mappingproxy({})
-getattr(ParamClass, IMPL).protected  # mappingproxy({'__paramclass_impl_': None, '__dict__': None, '__init__': <class 'paramclasses.paramclasses.RawParamClass'>, '__getattribute__': <class 'paramclasses.paramclasses.RawParamClass'>, '__setattr__': <class 'paramclasses.paramclasses.RawParamClass'>, '__delattr__': <class 'paramclasses.paramclasses.RawParamClass'>, 'set_params': <class 'paramclasses.paramclasses.ParamClass'>, 'params': <class 'paramclasses.paramclasses.ParamClass'>, 'missing_params': <class 'paramclasses.paramclasses.ParamClass'>})
+getattr(ParamClass, IMPL).annotations  # mappingproxy({})
+getattr(ParamClass, IMPL).protected    # mappingproxy({'__paramclass_impl_': None, '__dict__': None, '__init__': <class 'paramclasses.paramclasses.RawParamClass'>, '__getattribute__': <class 'paramclasses.paramclasses.RawParamClass'>, '__setattr__': <class 'paramclasses.paramclasses.RawParamClass'>, '__delattr__': <class 'paramclasses.paramclasses.RawParamClass'>, 'set_params': <class 'paramclasses.paramclasses.ParamClass'>, 'params': <class 'paramclasses.paramclasses.ParamClass'>, 'missing_params': <class 'paramclasses.paramclasses.ParamClass'>})
 # Works on subclasses and instances too
 ```
 

--- a/test/paramclasses/test_paramclasses.py
+++ b/test/paramclasses/test_paramclasses.py
@@ -177,3 +177,32 @@ def test_default_update():
     assert str(a) == "A(x=1)"
     A.x = 1
     assert str(a) == "A()"
+
+
+def test_post_init():
+    """Test trivial `__post_init__` use."""
+
+    class A(ParamClass):
+        def __post_init__(self, arg1, arg2) -> None:
+            self.arg1 = arg1
+            self.arg2 = arg2
+
+    arg1, arg2 = object(), object()
+
+    for a in (
+        A([arg1, arg2]),
+        A([arg1], {"arg2": arg2}),
+        A([], {"arg1": arg1, "arg2": arg2}),
+        A(None, {"arg1": arg1, "arg2": arg2}),
+    ):
+        assert a.arg1 is arg1
+        assert a.arg2 is arg2
+
+
+def test_unexpected_post_init_arguments(make):
+    """Check that provided arguments raise error when no post-init."""
+    Param = make("Param")
+
+    regex = r"^Unexpected positional arguments \(no `__post_init__` is defined\)$"
+    with pytest.raises(TypeError, match=regex):
+        Param(1)

--- a/test/paramclasses/test_paramclasses.py
+++ b/test/paramclasses/test_paramclasses.py
@@ -1,7 +1,5 @@
 """Miscellaneous tests not directly related to protection."""
 
-from inspect import signature
-
 import pytest
 
 from paramclasses import MISSING, ParamClass, RawParamClass, isparamclass
@@ -151,19 +149,6 @@ def test_isparamclass_raw():
 
     assert not isparamclass(RawParam)
     assert isparamclass(RawParam, raw=True)
-
-
-def test_signature():
-    """Test `__signature__` property."""
-
-    class A(ParamClass):
-        x: float  # type:ignore[annotation-unchecked]
-        y: int = 0  # type:ignore[annotation-unchecked]
-        z: str = 0  # type:ignore[annotation-unchecked]
-        t = 0
-
-    expected = "<Signature (*, x: float = ?, y: int = 0, z: str = 0)>"
-    assert repr(signature(A)) == expected
 
 
 def test_default_update():

--- a/test/paramclasses/test_signature.py
+++ b/test/paramclasses/test_signature.py
@@ -1,0 +1,125 @@
+"""Test the `__signature__` property."""
+
+from inspect import signature
+
+import pytest
+
+from paramclasses import ParamClass
+
+
+def test_signature_no_post_init():
+    """Test `__signature__` property."""
+
+    class A(ParamClass):
+        x: float  # type:ignore[annotation-unchecked]
+        y: int = 0  # type:ignore[annotation-unchecked]
+        z: str = 0  # type:ignore[annotation-unchecked]
+        t = 0
+
+    expected = "(*, x: float = ?, y: int = 0, z: str = 0)"
+    assert signature(A).format() == expected
+
+
+def test_signature_with_post_init():
+    """Test `__signature__` property."""
+
+    class A(ParamClass):
+        x: float  # type:ignore[annotation-unchecked]
+        y: int = 0  # type:ignore[annotation-unchecked]
+        z: str = 0  # type:ignore[annotation-unchecked]
+        t = 0
+
+        def __post_init__(self, a, b, c) -> None:
+            """Test with standard method."""
+
+    expected = (
+        "(post_init_args=[], post_init_kwargs={}, /, "
+        "*, x: float = ?, y: int = 0, z: str = 0)"
+    )
+    assert signature(A).format() == expected
+
+
+def test_signature_post_init_pos_and_kw():
+    """Test `__signature__` property with `__post_init__`.
+
+    Test classical method, staticmethod and classmethod.
+    """
+
+    class A(ParamClass):
+        def __post_init__(self, a, /, b, *, c) -> None:
+            """Test with standard method."""
+
+    class B(ParamClass):
+        @classmethod
+        def __post_init__(cls, a, /, b, *, c) -> None:
+            """Test with classmethod."""
+
+    class C(ParamClass):
+        @staticmethod
+        def __post_init__(a, /, b, *, c) -> None:
+            """Test with staticmethod."""
+
+    expected = "(post_init_args=[], post_init_kwargs={}, /)"
+    for cls in [A, B, C]:
+        assert signature(cls).format() == expected
+
+
+def test_signature_post_init_pos_only():
+    """Test `__signature__` property with `__post_init__`.
+
+    Test classical method, staticmethod and classmethod.
+    """
+
+    class A(ParamClass):
+        def __post_init__(self, a, /) -> None:
+            """Test with standard method."""
+
+    class B(ParamClass):
+        @classmethod
+        def __post_init__(cls, a, /) -> None:
+            """Test with classmethod."""
+
+    class C(ParamClass):
+        @staticmethod
+        def __post_init__(a, /) -> None:
+            """Test with staticmethod."""
+
+    expected = "(post_init_args=[], /)"
+    for cls in [A, B, C]:
+        assert signature(cls).format() == expected
+
+
+def test_signature_post_init_kw_only():
+    """Test `__signature__` property with `__post_init__`.
+
+    Test classical method, staticmethod and classmethod.
+    """
+
+    class A(ParamClass):
+        def __post_init__(self, *, c) -> None:
+            """Test with standard method."""
+
+    class B(ParamClass):
+        @classmethod
+        def __post_init__(cls, *, c) -> None:
+            """Test with classmethod."""
+
+    class C(ParamClass):
+        @staticmethod
+        def __post_init__(*, c) -> None:
+            """Test with staticmethod."""
+
+    expected = "(post_init_kwargs={}, /)"
+    for cls in [A, B, C]:
+        assert signature(cls).format() == expected
+
+
+def test_post_init_must_be_callable():
+    """Test `__signature__` error when `__post_init__` not callable."""
+
+    class A(ParamClass):
+        __post_init__ = 0
+
+    regex = r"^'__post_init__' attribute must be callable$"
+    with pytest.raises(TypeError, match=regex):
+        A.__signature__  # noqa: B018 (not useless)


### PR DESCRIPTION
- remove default `__post_init__` noop. This method is optional.
- `__signature__` now takes into account `__post_init__` signature. Examples:
```python
(*, x: float = ?, y: int = 0, z: str = 0)
(post_init_args=[], post_init_kwargs={}, /, *, x: float = ?, y: int = 0, z: str = 0)
(post_init_args=[], post_init_kwargs={}, /)
(post_init_args=[], /)    # `__post_init__` does not accept keyword arguments
(post_init_kwargs={}, /)  # `__post_init__` does not accept positional arguments
()                        # `__post_init__` does not accept arguments or no `__post_init__`
```